### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Test
         run: go test ./...
@@ -59,11 +59,11 @@ jobs:
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.14.1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_API_KEY }}
@@ -72,7 +72,7 @@ jobs:
       - name: Build and push Docker images
         # You may pin to the exact commit or the version.
         # uses: docker/build-push-action@ab83648e2e224cfeeab899e23b639660765c3a89
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
         with:
           # Docker repository to tag the image with
           context: .


### PR DESCRIPTION
## What
Pins all third-party (and in-org composite) GitHub Action `uses:` references to a full-length 40-character commit SHA, with the original tag preserved in a trailing comment that Dependabot reads for updates.

## Why
Org-wide supply-chain hardening: the enterprise "require actions pinned to a full-length commit SHA" policy is enforcing, so any workflow with tag-pinned refs will fail CI. Mutable tags can also be repointed to a malicious commit by an attacker who compromises an action's repo (see the recent [Megalodon campaign](https://safedep.io/megalodon-mass-github-repo-backdooring-ci-workflows/) — 5k+ repos backdoored in a 6-hour window).

## Behaviour change
None. Each action runs at the same commit as the tag it was already on.
Generated by `pinact`.